### PR TITLE
ScanSummary getters & unit tests

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -93,7 +93,7 @@ func (ds *DirectoryScanner) processDirectory(path string) error {
 	ds.logger.Debug().
 		Str("path", path).
 		Msg("Directory found, nothing to do here.")
-	ds.summary.directories++
+	ds.summary.AddDirectory()
 	return nil
 }
 
@@ -102,13 +102,13 @@ func (ds *DirectoryScanner) processFile(path string) error {
 		Str("path", path).
 		Msg("File found, the check is expected")
 
-	ds.summary.files++
+	ds.summary.AddFile()
 	checkRes, err := ds.checker.Check(path)
 	if err != nil {
 		ds.logger.Warn().
 			Str("path", path).
 			Msgf("Cannot check file: %v", err)
-		ds.summary.errors++
+		ds.summary.AddError()
 		return err
 	}
 
@@ -117,11 +117,11 @@ func (ds *DirectoryScanner) processFile(path string) error {
 		Str("hash", checkRes).
 		Msg("File was checked")
 
-	if ds.summary.files%summaryPeriod == 0 {
+	if ds.summary.Files()%summaryPeriod == 0 {
 		ds.logger.Info().Msgf(
 			"%d files processed, errors: %d...",
-			ds.summary.files,
-			ds.summary.errors,
+			ds.summary.Files(),
+			ds.summary.Errors(),
 		)
 	}
 

--- a/internal/scanner/summary.go
+++ b/internal/scanner/summary.go
@@ -22,3 +22,19 @@ func (s ScanSummary) Errors() int {
 func (s ScanSummary) Skipped() int {
 	return s.skipped
 }
+
+func (s *ScanSummary) AddFile() {
+	s.files++
+}
+
+func (s *ScanSummary) AddDirectory() {
+	s.directories++
+}
+
+func (s *ScanSummary) AddError() {
+	s.errors++
+}
+
+func (s *ScanSummary) AddSkipped() {
+	s.skipped++
+}

--- a/internal/scanner/summary_test.go
+++ b/internal/scanner/summary_test.go
@@ -1,0 +1,97 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanSummary_InitialState(t *testing.T) {
+	// Arrange & Act
+	summary := &ScanSummary{}
+
+	// Assert
+	assert.Equal(t, 0, summary.Files(), "Files should be 0 initially")
+	assert.Equal(t, 0, summary.Directories(), "Directories should be 0 initially")
+	assert.Equal(t, 0, summary.Errors(), "Errors should be 0 initially")
+	assert.Equal(t, 0, summary.Skipped(), "Skipped should be 0 initially")
+}
+
+func TestScanSummary_AddFile(t *testing.T) {
+	// Arrange
+	summary := &ScanSummary{}
+
+	// Act
+	summary.AddFile()
+
+	// Assert
+	assert.Equal(t, 1, summary.Files(), "Files should be 1 after AddFile()")
+	assert.Equal(t, 0, summary.Directories(), "Directories should remain 0")
+	assert.Equal(t, 0, summary.Errors(), "Errors should remain 0")
+	assert.Equal(t, 0, summary.Skipped(), "Skipped should remain 0")
+}
+
+func TestScanSummary_AddDirectory(t *testing.T) {
+	// Arrange
+	summary := &ScanSummary{}
+
+	// Act
+	summary.AddDirectory()
+
+	// Assert
+	assert.Equal(t, 0, summary.Files(), "Files should remain 0")
+	assert.Equal(t, 1, summary.Directories(), "Directories should be 1 after AddDirectory()")
+	assert.Equal(t, 0, summary.Errors(), "Errors should remain 0")
+	assert.Equal(t, 0, summary.Skipped(), "Skipped should remain 0")
+}
+
+func TestScanSummary_AddError(t *testing.T) {
+	// Arrange
+	summary := &ScanSummary{}
+
+	// Act
+	summary.AddError()
+
+	// Assert
+	assert.Equal(t, 0, summary.Files(), "Files should remain 0")
+	assert.Equal(t, 0, summary.Directories(), "Directories should remain 0")
+	assert.Equal(t, 1, summary.Errors(), "Errors should be 1 after AddError()")
+	assert.Equal(t, 0, summary.Skipped(), "Skipped should remain 0")
+}
+
+func TestScanSummary_AddSkipped(t *testing.T) {
+	// Arrange
+	summary := &ScanSummary{}
+
+	// Act
+	summary.AddSkipped()
+
+	// Assert
+	assert.Equal(t, 0, summary.Files(), "Files should remain 0")
+	assert.Equal(t, 0, summary.Directories(), "Directories should remain 0")
+	assert.Equal(t, 0, summary.Errors(), "Errors should remain 0")
+	assert.Equal(t, 1, summary.Skipped(), "Skipped should be 1 after AddSkipped()")
+}
+
+func TestScanSummary_MultipleIncrements(t *testing.T) {
+	// Arrange
+	summary := &ScanSummary{}
+
+	// Act
+	summary.AddFile()
+	summary.AddFile()
+	summary.AddFile()
+	summary.AddDirectory()
+	summary.AddDirectory()
+	summary.AddError()
+	summary.AddSkipped()
+	summary.AddSkipped()
+	summary.AddSkipped()
+	summary.AddSkipped()
+
+	// Assert
+	assert.Equal(t, 3, summary.Files(), "Files should be 3 after 3 AddFile() calls")
+	assert.Equal(t, 2, summary.Directories(), "Directories should be 2 after 2 AddDirectory() calls")
+	assert.Equal(t, 1, summary.Errors(), "Errors should be 1 after 1 AddError() call")
+	assert.Equal(t, 4, summary.Skipped(), "Skipped should be 4 after 4 AddSkipped() calls")
+}


### PR DESCRIPTION
`ScanSummary` is used to collect processing stats. 

**Problem:**
The old implementation is about working with fields directly. It's a bad solution in terms of future improvements (at least locks adding).

**Changes:**
- to add methods for values increments (e.g. `AddFile`)
- to use getters and increment methods for all external changes
- unit tests to make sure everything works properly