### PR TITLE
ScanSummary improvements

### DIFF
--- a/internal/parameters/parameters_test.go
+++ b/internal/parameters/parameters_test.go
@@ -90,3 +90,4 @@ func TestParseParameters(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -15,7 +15,7 @@ type DirectoryScanner struct {
 	logger       zerolog.Logger
 	checker      FileChecker
 	scannedPaths map[string]bool
-	summary      *ScanSummary
+	summary      *ScanSummaryCollector
 	mu           sync.RWMutex
 }
 
@@ -28,7 +28,7 @@ func NewDirectoryScanner(logger zerolog.Logger, checker FileChecker) *DirectoryS
 		logger:       logger,
 		checker:      checker,
 		scannedPaths: make(map[string]bool),
-		summary:      &ScanSummary{},
+		summary:      &ScanSummaryCollector{},
 		mu:           sync.RWMutex{},
 	}
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -50,7 +50,6 @@ func (ds *DirectoryScanner) Scan(rootPath string) error {
 	}
 
 	ds.logger.Info().Msgf("Starting directory scan: %s", absPath)
-
 	err = filepath.WalkDir(absPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -72,9 +71,8 @@ func (ds *DirectoryScanner) Scan(rootPath string) error {
 	return nil
 }
 
-func (ds *DirectoryScanner) Summary() ScanSummary {
-	// Return a copy of the summary to prevent external modifications
-	return *ds.summary
+func (ds *DirectoryScanner) Summary() ScanSummaryStats {
+	return ds.summary.Stats()
 }
 
 func (ds *DirectoryScanner) isPathScanned(absPath string) bool {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,130 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFileChecker struct {
+	mu            sync.Mutex
+	checkCount    int
+	checkDuration time.Duration
+	shouldError   bool
+}
+
+func (m *mockFileChecker) Check(path string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	
+	m.checkCount++
+	
+	if m.checkDuration > 0 {
+		time.Sleep(m.checkDuration)
+	}
+	
+	if m.shouldError {
+		return "", fmt.Errorf("mock error for %s", path)
+	}
+	
+	return fmt.Sprintf("hash-%s", filepath.Base(path)), nil
+}
+
+func (m *mockFileChecker) getCheckCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.checkCount
+}
+
+func TestNewDirectoryScanner(t *testing.T) {
+	logger := zerolog.New(os.Stdout).Level(zerolog.Disabled)
+	checker := &mockFileChecker{}
+
+	t.Run("creates scanner successfully", func(t *testing.T) {
+		scanner := NewDirectoryScanner(logger, checker)
+		assert.NotNil(t, scanner)
+		assert.NotNil(t, scanner.summary)
+		assert.NotNil(t, scanner.scannedPaths)
+	})
+}
+
+func TestDirectoryScanner_BasicFunctionality(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := zerolog.New(os.Stdout).Level(zerolog.Disabled)
+
+	// Create test files
+	testFiles := []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt"}
+	for _, filename := range testFiles {
+		err := os.WriteFile(filepath.Join(tempDir, filename), []byte("test content"), 0644)
+		require.NoError(t, err)
+	}
+
+	t.Run("processes all files successfully", func(t *testing.T) {
+		checker := &mockFileChecker{}
+		scanner := NewDirectoryScanner(logger, checker)
+
+		err := scanner.Scan(tempDir)
+
+		require.NoError(t, err)
+		assert.Equal(t, len(testFiles), checker.getCheckCount())
+		summary := scanner.Summary()
+		assert.Equal(t, len(testFiles), summary.Files())
+		assert.Equal(t, 1, summary.Directories())
+		assert.Equal(t, 0, summary.Errors())
+	})
+
+	t.Run("handles file check errors", func(t *testing.T) {
+		checker := &mockFileChecker{shouldError: true}
+		scanner := NewDirectoryScanner(logger, checker)
+
+		err := scanner.Scan(tempDir)
+		require.Error(t, err) // Scan should error on first file check failure
+
+		// Only one file should be processed before error stops the scan
+		assert.Equal(t, 1, checker.getCheckCount())
+		summary := scanner.Summary()
+		assert.Equal(t, 1, summary.Files())
+		assert.Equal(t, 1, summary.Errors())
+	})
+}
+
+func TestDirectoryScanner_ScanSummary(t *testing.T) {
+	tempDir := t.TempDir()
+	logger := zerolog.New(os.Stdout).Level(zerolog.Disabled)
+
+	// Create test files in subdirectory
+	subDir := filepath.Join(tempDir, "subdir")
+	err := os.Mkdir(subDir, 0755)
+	require.NoError(t, err)
+
+	numFiles := 10
+	for i := 0; i < numFiles; i++ {
+		filename := fmt.Sprintf("file%d.txt", i)
+		err := os.WriteFile(filepath.Join(tempDir, filename), []byte("test content"), 0644)
+		require.NoError(t, err)
+	}
+
+	// Create one file in subdirectory
+	err = os.WriteFile(filepath.Join(subDir, "subfile.txt"), []byte("sub content"), 0644)
+	require.NoError(t, err)
+
+	checker := &mockFileChecker{}
+	scanner := NewDirectoryScanner(logger, checker)
+
+	err = scanner.Scan(tempDir)
+	require.NoError(t, err)
+
+	// Verify scan summary
+	assert.Equal(t, numFiles+1, checker.getCheckCount()) // +1 for subfile
+	summary := scanner.Summary()
+	assert.Equal(t, numFiles+1, summary.Files())
+	assert.Equal(t, 2, summary.Directories()) // tempDir + subDir
+	assert.Equal(t, 0, summary.Errors())
+}

--- a/internal/scanner/summary.go
+++ b/internal/scanner/summary.go
@@ -25,60 +25,60 @@ func (s ScanSummaryStats) Skipped() int {
 	return s.skipped
 }
 
-type ScanSummary struct {
+type ScanSummaryCollector struct {
 	data ScanSummaryStats
 	mu   sync.RWMutex
 }
 
-func (s *ScanSummary) Files() int {
+func (s *ScanSummaryCollector) Files() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.data.files
 }
 
-func (s *ScanSummary) Directories() int {
+func (s *ScanSummaryCollector) Directories() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.data.directories
 }
 
-func (s *ScanSummary) Errors() int {
+func (s *ScanSummaryCollector) Errors() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.data.errors
 }
 
-func (s *ScanSummary) Skipped() int {
+func (s *ScanSummaryCollector) Skipped() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.data.skipped
 }
 
-func (s *ScanSummary) AddFile() {
+func (s *ScanSummaryCollector) AddFile() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.data.files++
 }
 
-func (s *ScanSummary) AddDirectory() {
+func (s *ScanSummaryCollector) AddDirectory() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.data.directories++
 }
 
-func (s *ScanSummary) AddError() {
+func (s *ScanSummaryCollector) AddError() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.data.errors++
 }
 
-func (s *ScanSummary) AddSkipped() {
+func (s *ScanSummaryCollector) AddSkipped() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.data.skipped++
 }
 
-func (s *ScanSummary) Stats() ScanSummaryStats {
+func (s *ScanSummaryCollector) Stats() ScanSummaryStats {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.data

--- a/internal/scanner/summary.go
+++ b/internal/scanner/summary.go
@@ -1,40 +1,85 @@
 package scanner
 
-type ScanSummary struct {
+import "sync"
+
+type ScanSummaryStats struct {
 	files       int
 	directories int
 	errors      int
 	skipped     int
 }
 
-func (s ScanSummary) Files() int {
+func (s ScanSummaryStats) Files() int {
 	return s.files
 }
 
-func (s ScanSummary) Directories() int {
+func (s ScanSummaryStats) Directories() int {
 	return s.directories
 }
 
-func (s ScanSummary) Errors() int {
+func (s ScanSummaryStats) Errors() int {
 	return s.errors
 }
 
-func (s ScanSummary) Skipped() int {
+func (s ScanSummaryStats) Skipped() int {
 	return s.skipped
 }
 
+type ScanSummary struct {
+	data ScanSummaryStats
+	mu   sync.RWMutex
+}
+
+func (s *ScanSummary) Files() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data.files
+}
+
+func (s *ScanSummary) Directories() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data.directories
+}
+
+func (s *ScanSummary) Errors() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data.errors
+}
+
+func (s *ScanSummary) Skipped() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data.skipped
+}
+
 func (s *ScanSummary) AddFile() {
-	s.files++
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data.files++
 }
 
 func (s *ScanSummary) AddDirectory() {
-	s.directories++
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data.directories++
 }
 
 func (s *ScanSummary) AddError() {
-	s.errors++
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data.errors++
 }
 
 func (s *ScanSummary) AddSkipped() {
-	s.skipped++
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data.skipped++
+}
+
+func (s *ScanSummary) Stats() ScanSummaryStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data
 }

--- a/internal/scanner/summary_test.go
+++ b/internal/scanner/summary_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestScanSummary_InitialState(t *testing.T) {
 	// Arrange & Act
-	summary := &ScanSummary{}
+	summary := &ScanSummaryCollector{}
 
 	// Assert
 	assert.Equal(t, 0, summary.Files(), "Files should be 0 initially")
@@ -19,7 +19,7 @@ func TestScanSummary_InitialState(t *testing.T) {
 
 func TestScanSummary_AddFile(t *testing.T) {
 	// Arrange
-	summary := &ScanSummary{}
+	summary := &ScanSummaryCollector{}
 
 	// Act
 	summary.AddFile()
@@ -33,7 +33,7 @@ func TestScanSummary_AddFile(t *testing.T) {
 
 func TestScanSummary_AddDirectory(t *testing.T) {
 	// Arrange
-	summary := &ScanSummary{}
+	summary := &ScanSummaryCollector{}
 
 	// Act
 	summary.AddDirectory()
@@ -47,7 +47,7 @@ func TestScanSummary_AddDirectory(t *testing.T) {
 
 func TestScanSummary_AddError(t *testing.T) {
 	// Arrange
-	summary := &ScanSummary{}
+	summary := &ScanSummaryCollector{}
 
 	// Act
 	summary.AddError()
@@ -61,7 +61,7 @@ func TestScanSummary_AddError(t *testing.T) {
 
 func TestScanSummary_AddSkipped(t *testing.T) {
 	// Arrange
-	summary := &ScanSummary{}
+	summary := &ScanSummaryCollector{}
 
 	// Act
 	summary.AddSkipped()
@@ -75,7 +75,7 @@ func TestScanSummary_AddSkipped(t *testing.T) {
 
 func TestScanSummary_MultipleIncrements(t *testing.T) {
 	// Arrange
-	summary := &ScanSummary{}
+	summary := &ScanSummaryCollector{}
 
 	// Act
 	summary.AddFile()


### PR DESCRIPTION
1. Adding `sync.RWMutex` to make it thread safe
2. `ScanSummary` logic split to `ScanSummaryCollector` (to keep updates and locks) and `ScanSummaryStats` (to store the results)
3. Additional (integration) tests for `DirectoryScanner` to check `ScanSummaryStats` results